### PR TITLE
Fixes to spec file to allow rpm builds to succeed

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,13 +9,13 @@ mkdir -p $OPENSHIFT_AMQ_DIR
 cd $OPENSHIFT_AMQ_DIR
 
 # First, try to to get the file from the public repo, the fallback to getting it from the EA repo.
-curl -f --silent --output jboss-a-mq-${version}.zip \
-  https://repository.jboss.org/nexus/content/groups/public/org/jboss/amq/jboss-a-mq/${version}/jboss-a-mq-${version}.zip || true
+#curl -f --silent --output jboss-a-mq-${version}.zip \
+#  https://repository.jboss.org/nexus/content/groups/public/org/jboss/amq/jboss-a-mq/${version}/jboss-a-mq-${version}.zip || true
   
-if [ ! -f 'jboss-a-mq-${version}.zip' ]; then  
-  curl -f --silent --output jboss-a-mq-${version}.zip \
-    https://repository.jboss.org/nexus/content/repositories/ea/org/jboss/amq/jboss-a-mq/${version}/jboss-a-mq-${version}.zip
-fi
+#if [ ! -f 'jboss-a-mq-${version}.zip' ]; then  
+#  curl -f --silent --output jboss-a-mq-${version}.zip \
+#    https://repository.jboss.org/nexus/content/repositories/ea/org/jboss/amq/jboss-a-mq/${version}/jboss-a-mq-${version}.zip
+#fi
 
 unzip jboss-a-mq-${version}.zip
 ln -s jboss-a-mq-${version} container

--- a/openshift-origin-cartridge-amq.spec
+++ b/openshift-origin-cartridge-amq.spec
@@ -44,7 +44,6 @@ rm -rf %{buildroot}
 %dir %{cartridgedir}/versions
 %attr(0755,-,-) %{cartridgedir}/bin/
 %attr(0755,-,-) %{frameworkdir}
-%{_sysconfdir}/openshift/cartridges/v2/%{name}
 %{cartridgedir}/metadata/manifest.yml
 %doc %{cartridgedir}/README.md
 %doc %{cartridgedir}/COPYRIGHT

--- a/openshift-origin-cartridge-amq.spec
+++ b/openshift-origin-cartridge-amq.spec
@@ -55,7 +55,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Thu March 24 2014 Hiram Chirino <hchirino@redhat.com> 0.1.0
+* Thu March 24 2014 Hiram Chirino <hchirino@redhat.com> 0.1.0-1
 - Initial implementation based on the AMQ cartridge
 
 

--- a/openshift-origin-cartridge-amq.spec
+++ b/openshift-origin-cartridge-amq.spec
@@ -1,5 +1,5 @@
-%global cartridgedir %{_libexecdir}/openshift/cartridges/v2/amq
-%global frameworkdir %{_libexecdir}/openshift/cartridges/v2/amq
+%global cartridgedir %{_libexecdir}/openshift/cartridges/amq
+%global frameworkdir %{_libexecdir}/openshift/cartridges/amq
 
 Name: openshift-origin-cartridge-amq
 Version: 0.1.0
@@ -8,7 +8,7 @@ Summary: Red Hat JBoss A-MQ cartridge
 Group: Development/Languages
 License: ASL 2.0
 URL: https://www.openshift.com
-Source0: http://mirror.openshift.com/pub/origin-server/source/%{name}/%{name}-%{version}.tar.gz
+Source0: %{name}-%{version}.tar.gz
 Requires:      rubygem(openshift-origin-node)
 Requires:      openshift-origin-node-util
 
@@ -27,10 +27,7 @@ Red Hat JBoss A-MQ cartridge for openshift. (Cartridge Format V2)
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}%{cartridgedir}
-mkdir -p %{buildroot}/%{_sysconfdir}/openshift/cartridges/v2
 cp -r * %{buildroot}%{cartridgedir}/
-ln -s %{cartridgedir}/conf/ %{buildroot}/%{_sysconfdir}/openshift/cartridges/v2/%{name}
-
 
 %clean
 rm -rf %{buildroot}

--- a/openshift-origin-cartridge-amq.spec
+++ b/openshift-origin-cartridge-amq.spec
@@ -55,7 +55,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Thu March 24 2014 Hiram Chirino <hchirino@redhat.com> 0.1.0-1
+* Thu Mar 24 2014 Hiram Chirino <hchirino@redhat.com> 0.1.0-1
 - Initial implementation based on the AMQ cartridge
 
 


### PR DESCRIPTION
There were a few formatting issues in the %changelog section of the spec file that were causing rpm builds to fail in RHEL.
